### PR TITLE
Moved webhook out of config

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,4 @@
 Config = {
-    Webhook = '',
     TowTruckDrivers = {'S_M_M_TRUCKER_01', 'MP_M_WAREMECH_01'},
     NoClipTriggerCount = 3,
     BlacklistedEvents = {

--- a/server.lua
+++ b/server.lua
@@ -1,5 +1,7 @@
 BlacklistedEvents = Config.BlacklistedEvents;
 
+webhookURL = ''
+
 local counter = {}
 RegisterServerEvent("Anticheat:NoClip")
 AddEventHandler("Anticheat:NoClip", function(distance)
@@ -195,7 +197,7 @@ function ExtractIdentifiers(src)
 
     return identifiers
 end
-webhookURL = Config.Webhook;
+
 function sendToDisc(title, message, footer)
     local embed = {}
     embed = {


### PR DESCRIPTION
By dumping the config file, you can easily access the webhook to spam/do whatever you want with it. This commit moves it server side to avoid unauthorized access.