### PR TITLE
Update server.lua

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -736,7 +736,7 @@ CreateThread(function()
                 for k, v in pairs({'fxmanifest.lua', '__resource.lua'}) do
                     local data = LoadResourceFile(resource_name, v)
                     if data and type(data) == 'string' and string.find(data, 'acloader.lua') ~= nil then
-                        data = data:lower()
+                       -- data = data:lower()
                         local removed = string.gsub(data, 'client_script "%@badger%-anticheat%-master%/acloader.lua"', "")
                         SaveResourceFile(resource_name, v, removed, -1)
                         print('Removed from resource: ' .. resource_name)


### PR DESCRIPTION
data.lower() corrupts _resource.lua or fxmanifest.lua data.
For example:
server_script '@mysql-async/lib/MySQL.lua' changes to -> server_script '@mysql-async/lib/mysql.lua'

And scripts never loads MySQL Api.
Imagine fixing over 200 resources..